### PR TITLE
Set content-length when known.

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ module.exports = function * (next) {
     this.body = rawBody.slice.apply(rawBody, args);
   }
 
-  if(len !== '*') {
+  if (len !== '*') {
     this.length = end - start + 1;
   }
 };

--- a/index.js
+++ b/index.js
@@ -74,6 +74,10 @@ module.exports = function * (next) {
   } else {
     this.body = rawBody.slice.apply(rawBody, args);
   }
+
+  if(len !== '*') {
+    this.length = end - start + 1;
+  }
 };
 
 function rangeParse(str) {

--- a/test/simple.js
+++ b/test/simple.js
@@ -133,6 +133,7 @@ describe('range requests with stream', function() {
     request(app.listen())
     .get('/stream')
     .set('range', 'bytes=0-')
+    .expect('Transfer-Encoding', 'chunked')
     .expect(200)
     .end(function(err, res) {
       should.not.exist(err);
@@ -151,6 +152,7 @@ describe('range requests with json', function() {
     .set('range', 'bytes=0-5')
     .expect('Accept-Ranges', 'bytes')
     .expect('Content-Range', 'bytes 0-5/13')
+    .expect('Content-Length', '6')
     .expect(206)
     .end(function(err, res) {
       should.not.exist(err);
@@ -165,6 +167,7 @@ describe('range requests with json', function() {
     .set('range', 'bytes=2-2')
     .expect('Accept-Ranges', 'bytes')
     .expect('Content-Range', 'bytes 2-2/13')
+    .expect('Content-Length', '1')
     .expect(206)
     .end(function(err, res) {
       should.not.exist(err);
@@ -185,6 +188,7 @@ describe('range requests with string', function() {
     .set('range', 'bytes=0-5')
     .expect('Accept-Ranges', 'bytes')
     .expect('Content-Range', 'bytes 0-5/9')
+    .expect('Content-Length', '6')
     .expect(206)
     .end(function(err, res) {
       should.not.exist(err);
@@ -199,6 +203,7 @@ describe('range requests with string', function() {
     .set('range', 'bytes=3-')
     .expect('Accept-Ranges', 'bytes')
     .expect('Content-Range', 'bytes 3-8/9')
+    .expect('Content-Length', '6')
     .expect(206)
     .end(function(err, res) {
       should.not.exist(err);


### PR DESCRIPTION
If we can determine the length of the response, it should be set in the Content-Length header.

Now, it was some time ago I wrote this but I think that this fixed and issue with video/sound seeking in Firefox (or Chrome).