### PR TITLE
re-write with the goal of better spec compliance (rfc7233, rfc7232)

### DIFF
--- a/buffer-stream.js
+++ b/buffer-stream.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const Readable = require('stream').Readable;
+
+
+// Give it a Node.js Buffer and it'll give you a Node.js Readable Stream; that's all!
+//
+// Inspired by https://www.npmjs.com/package/simple-bufferstream but with more modern
+// node stream handling
+module.exports = function readableBufferStream (srcBuf) {
+  let bytesRead = 0;
+
+  return new Readable({
+    read (size) {
+      const remaining = srcBuf.length - bytesRead;
+      if (remaining > 0) {
+        const toRead = Math.min(size, remaining);
+        this.push(srcBuf.slice(bytesRead, bytesRead + toRead));
+        bytesRead += toRead;
+      } else {
+        this.push(null);
+      }
+    }
+  });
+}

--- a/error.js
+++ b/error.js
@@ -1,0 +1,38 @@
+'use strict';
+
+module.exports = error;
+
+
+// common http error status handler
+// @param Object err an object of http headers to set
+function error (ctx, status, err) {
+
+  const keys = Object.keys(ctx.response.headers);
+
+  for (let i=0; i < keys.length; i++)
+    ctx.remove(keys[i]);
+  
+  if (err && err.headers)
+    setHeaders(ctx, err.headers);
+
+  ctx.set('Accept-Ranges', 'bytes');
+  ctx.status = status;
+}
+
+
+/**
+ * Set an object of headers on a response.
+ *
+ * @param {object} res
+ * @param {object} headers
+ * @private
+ */
+
+function setHeaders (ctx, headers) {
+  const keys = Object.keys(headers);
+
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i];
+    ctx.set(key, headers[key]);
+  }
+}

--- a/fresh.js
+++ b/fresh.js
@@ -1,0 +1,141 @@
+/*!
+ * fresh
+ * Copyright(c) 2012 TJ Holowaychuk
+ * Copyright(c) 2016-2017 Douglas Christopher Wilson
+ * MIT Licensed
+ */
+
+'use strict'
+
+/**
+ * RegExp to check for no-cache token in Cache-Control.
+ * @private
+ */
+
+var CACHE_CONTROL_NO_CACHE_REGEXP = /(?:^|,)\s*?no-cache\s*?(?:,|$)/
+
+/**
+ * Module exports.
+ * @public
+ */
+
+module.exports = fresh
+
+/**
+ * Check freshness of the response using request and response headers.
+ *
+ * @param {Object} reqHeaders
+ * @param {Object} resHeaders
+ * @return {Boolean}
+ * @public
+ */
+
+function fresh (reqHeaders, resHeaders) {
+  // fields
+  var modifiedSince = reqHeaders['if-modified-since']
+  var noneMatch = reqHeaders['if-none-match']
+
+  // unconditional request
+  if (!modifiedSince && !noneMatch) {
+    return false
+  }
+
+  // Always return stale when Cache-Control: no-cache
+  // to support end-to-end reload requests
+  // https://tools.ietf.org/html/rfc2616#section-14.9.4
+  var cacheControl = reqHeaders['cache-control']
+  if (cacheControl && CACHE_CONTROL_NO_CACHE_REGEXP.test(cacheControl)) {
+    return false
+  }
+
+  // if-none-match
+  if (noneMatch && noneMatch !== '*') {
+    var etag = resHeaders['etag']
+
+    if (!etag) {
+      return false
+    }
+
+    var etagStale = true
+    var matches = parseTokenList(noneMatch)
+    for (var i = 0; i < matches.length; i++) {
+      var match = matches[i]
+      if (match === etag || match === 'W/' + etag || 'W/' + match === etag) {
+        etagStale = false
+        break
+      }
+    }
+
+    if (etagStale) {
+      return false
+    }
+  }
+
+  // if-modified-since
+  if (modifiedSince) {
+    var lastModified = resHeaders['last-modified']
+    var modifiedStale = !lastModified || !(parseHttpDate(lastModified) <= parseHttpDate(modifiedSince))
+
+    if (modifiedStale) {
+      return false
+    }
+  }
+
+  return true
+}
+
+/**
+ * Parse an HTTP Date into a number.
+ *
+ * @param {string} date
+ * @private
+ */
+
+function parseHttpDate (date) {
+  var timestamp = date && Date.parse(date)
+
+  // istanbul ignore next: guard against date.js Date.parse patching
+  return typeof timestamp === 'number'
+    ? timestamp
+    : NaN
+}
+
+/**
+ * Parse a HTTP token list.
+ *
+ * @param {string} str
+ * @private
+ */
+
+function parseTokenList (str) {
+  var end = 0
+  var list = []
+  var start = 0
+
+  // gather tokens
+  for (var i = 0, len = str.length; i < len; i++) {
+    switch (str.charCodeAt(i)) {
+      case 0x20: /*   */
+        if (start === end) {
+          start = end = i + 1
+        }
+        break
+      case 0x2c: /* , */
+        if (start !== end) {
+          list.push(str.substring(start, end))
+        }
+        start = end = i + 1
+        break
+      default:
+        end = i + 1
+        break
+    }
+  }
+
+  // final token
+  if (start !== end) {
+    list.push(str.substring(start, end))
+  }
+
+  return list
+}

--- a/index.js
+++ b/index.js
@@ -1,8 +1,18 @@
-var util = require('util');
-var slice = require('stream-slice').slice;
-var Stream = require('stream');
+'use strict';
 
-const fs = require('fs');
+const error         = require('./error');
+const etag          = require('etag');
+const fresh         = require('fresh');
+const fs            = require('fs');
+const isPreconditionFailure = require('./is-precondition-failure');
+const mime          = require('mime');
+const parseHttpDate = require('./parse-http-date');
+const parseRange    = require('range-parser');
+const pump          = require('pump');
+const rangeStream   = require('range-stream');
+const sbuff         = require('./buffer-stream'); 
+const util          = require('util');
+const Stream        = require('stream');
 
 
 function stat (path) {
@@ -17,124 +27,242 @@ function stat (path) {
 }
 
 
+function isConditionalGET (request) {
+  return request.get('if-match') ||
+    request.get('if-unmodified-since') ||
+    request.get('if-none-match') ||
+    request.get('if-modified-since');
+}
+
+
+// Respond with 304 not modified.
+function notModified (ctx) {
+  const res = ctx.response;
+
+  // strip various content header fields for a change in entity.
+  res.remove('Content-Encoding');
+  res.remove('Content-Language');
+  res.remove('Content-Length');
+  res.remove('Content-Range');
+  res.remove('Content-Type');
+
+  ctx.body = null;
+  res.status = 304;
+}
+
+
+/**
+ * Check if the request is cacheable, aka
+ * responded with 2xx or 304 (see RFC 2616 section 14.2{5,6}).
+ *
+ * @return {Boolean}
+ */
+
+function isCachable (ctx) {
+  const statusCode = ctx.status;
+  return (statusCode >= 200 && statusCode < 300) || statusCode === 304;
+}
+
+
+/**
+ * Check if the cache is fresh.
+ *
+ * @return {Boolean}
+ */
+
+function isFresh (ctx) {
+  return fresh(ctx.request.headers, {
+    etag: ctx.response.get('ETag'),
+    'last-modified': ctx.response.get('Last-Modified')
+  });
+}
+
+
+/**
+ * Check if the range is fresh.
+ *
+ * @return {Boolean}
+ */
+
+function isRangeFresh (ctx) {
+  const ifRange = ctx.request.get('if-range');
+
+  if (!ifRange)
+    return true;
+
+  // if-range as etag
+  if (ifRange.indexOf('"') !== -1) {
+    const etag = ctx.response.get('ETag');
+    return Boolean(etag && ifRange.indexOf(etag) !== -1);
+  }
+
+  // if-range as modified date
+  const lastModified = ctx.response.get('Last-Modified');
+  return parseHttpDate(lastModified) <= parseHttpDate(ifRange);
+}
+
+
 module.exports = async function (ctx, next) {
-  var range = ctx.header.range;
-  ctx.set('Accept-Ranges', 'bytes');
-
-  if (!range) {
-    return next();
-  }
-
-  var ranges = rangeParse(range);
-
-  if (!ranges || ranges.length == 0) {
-    ctx.status = 416;
-    return;
-  }
-
-  if (ctx.method == 'PUT') {
-    ctx.status = 400;
-    return;
-  }
+  let stats;
 
   await next();
 
-  if (ctx.method != 'GET' ||
-     ctx.body == null) {
+  if (Buffer.isBuffer(ctx.body))
+    stats = ctx.body;
+  else if ((ctx.body instanceof Stream.Readable) && ctx.body.path)
+    stats = await stat(ctx.body.path);
+
+  
+  ctx.set('Accept-Ranges', 'bytes');
+
+  // a server MUST ignore a Range header field received with a request method other than GET
+  // rfc7233 section 3.1, paragraph 2
+  if (ctx.method !== 'GET')
     return;
-  }
 
-  var first = ranges[0];
-  var rawBody = ctx.body;
-  var len = rawBody.length;
+  // requests lacking a range header don't need further handling
+  //
+  // a server MUST ignore if-range header if request does not contain a range header
+  // rfc4233 section 3.2, paragraph 3
+  const range = ctx.request.get('range');
+  if (!range)
+    return;
 
-  // avoid multi ranges
-  var firstRange = ranges[0];
-  var start = firstRange[0];
-  var end = firstRange[1];
+  // responses lacking a body don't need further handling
+  //
+  // A server MUST ignore all received preconditions after it has successfully performed normal
+  // request checks and just before it would perform the action associated with the request method.
+  // A server MUST ignore all received preconditions if it's response to the same request without
+  // those conditions would have been a status code other than a 2xx (Successful) or 412 (Precondition
+  // Failed). i.e., redirects and failures take precendence over the evaluation of preconditions in
+  // conditional get requests
+  // rfc7232 section 5, paragraph 1
+  if (ctx.body == null || ctx.body === undefined)
+    return;
 
-  if (!Buffer.isBuffer(rawBody)) {
+  if (stats) {
+    //if (this._cacheControl && !res.get['Cache-Control'])
+    //  ctx.set('Cache-Control', 'public, max-age=' + Math.floor(this._maxage / 1000);
 
-    if (rawBody instanceof Stream.Readable) {
-      len = ctx.length || '*';
-
-      if (rawBody.path) {
-        let path = rawBody.path;
-        if (!Number.isInteger(len)) {
-          let stats = await stat(path);
-
-          len = stats.size;
-        }
-
-        rawBody = fs.createReadStream(rawBody.path, {
-          start,
-          end: end,
-        });
-      } else {
-        if (end === Infinity && !Number.isInteger(len)) {
-          return;
-        }
-        rawBody = rawBody.pipe(slice(start, end + 1));
-      }
-
-      
-    } else if (typeof rawBody !== 'string') {
-      rawBody = new Buffer(JSON.stringify(rawBody));
-      len = rawBody.length;
-    } else {
-      rawBody = new Buffer(rawBody);
-      len = rawBody.length;
+    if (!Buffer.isBuffer(stats)) {
+      if (/*this._lastModified &&*/ !ctx.response.get('Last-Modified'))
+        ctx.set('Last-Modified', stats.mtime.toUTCString());
     }
+
+    if (/*this._etag &&*/ !ctx.response.get('ETag'))
+      ctx.set('ETag', etag(stats));
   }
 
-  //Adjust infinite end
-  if (end === Infinity) {
-    if (Number.isInteger(len)) {
-      end = len - 1;
-    } else {
-      // FIXME(Calle Svensson): If we don't know how much we can return, we do a normal HTTP 200 repsonse
-      ctx.status = 200;
+  if (ctx.body && ctx.body.path && !ctx.response.get('Content-Type')) {
+    const type = mime.getType(ctx.body.path);
+    if (type)
+      ctx.set('Content-Type', type);
+  }
+
+
+  // this logic defined in implements rfc7232 section 6
+  // most of it came from the very comprehensive send npm module
+  // https://github.com/pillarjs/send/blob/master/index.js#L619-L636
+  if (isConditionalGET(ctx)) {
+    if (isPreconditionFailure(ctx)) {
+      ctx.body = null;
+      error(ctx, 412);
+      return;
+    }
+
+    if (isCachable(ctx) && isFresh(ctx)) {
+      // The range header field is evaluated after evaluating the precondition header fields defined in rfc7232,
+      // and only if the result in absence of a the Range header field would be a 200 (OK) response.
+      // i.e., Range is ignored when a conditional GET would result in a 304 (Not Modified) response.
+      // rfc 7233 section 3.1, paragraph 6
+
+      ctx.body = null;
+
+
+      notModified(ctx);
       return;
     }
   }
 
-  var args = [start, end+1].filter(function(item) {
-    return typeof item == 'number';
-  });
+  let stream, representationLength = Infinity;
 
-  ctx.set('Content-Range', rangeContentGenerator(start, end, len));
+  if (ctx.body instanceof Stream.Readable) {
+    if (ctx.body.path) {
+      representationLength = stats.size;
+    } else if (ctx.body.length) {
+      representationLength = ctx.body.length;
+    } else {
+      // can't determine the length of this readable stream, just stream the body like a normal non-range request
+      ctx.status = 200;
+      return;
+    }
+    stream = ctx.body;
+  } else if (!Buffer.isBuffer(ctx.body)) {
+    stream = (typeof ctx.body === 'string') ? Buffer.from(ctx.body) : Buffer.from(JSON.stringify(ctx.body));
+  } else {
+    stream = ctx.body;
+  }
+
+  if (Buffer.isBuffer(stream)) {
+    representationLength = stream.length;
+    stream = sbuff(stream);
+  }
+
+  let ranges = parseRange(representationLength, ctx.header.range, { combine: false });
+
+  if (representationLength === Infinity && (ranges.length > 0) && (ranges[0].start === Infinity)) {
+    // we've encountered a byte range that looks like:
+    //   -500         <- this means give us the last 500 bytes of the representation
+    // but because this is a stream of unknown length, we don't know what the last 500 bytes are.
+    ranges = -1; 
+  }
+
+  if (representationLength < Infinity)
+    ctx.set('Content-Length', representationLength);
+
+  if (ranges === -2) {
+    ctx.body = null;
+    ctx.status = 416;
+    return; // malformed range
+  }
+
+  const len = (representationLength === Infinity) ? '*' : representationLength;
+
+  if (ranges === -1) {
+    // unsatisfiable range
+    ctx.set('Content-Range', 'bytes */' + len);
+    ctx.body = null;
+    ctx.status = 416;
+    return;
+  }
+
+  if (!ranges || ranges.length === 0) {
+    ctx.body = null;
+    ctx.status = 416;
+    return;
+  }
+
+  // TODO: handle multiple ranges (for now we just always use the first one)
+  const start = ranges[0].start;
+  const end = ranges[0].end;
+
+  // Adjust infinite end
+  if (end === Infinity) {
+    if (representationLength < Infinity)
+      end = representationLength - 1;
+    else
+      // if we don't know how much to return, just assume a 16kb chunk is what we want. because sure why not :)
+      end = start + 16384 - 1;
+  }
+
+  ctx.set('Content-Range', util.format('bytes %d-%d/%s', start, end, len));
   ctx.status = 206;
 
-  if (rawBody instanceof Stream) {
-    ctx.body = rawBody;
-  } else {
-    ctx.body = rawBody.slice.apply(rawBody, args);
-  }
+  ctx.body = pump(
+    stream,
+    rangeStream(start, end)
+  )
 
-  if (len !== '*') {
-    ctx.length = end - start + 1;
-  }
+  //ctx.length = end - start+1;
+  ctx.set('Content-Length', end - start+1);
 };
-
-function rangeParse(str) {
-  var token = str.split('=');
-  if (!token || token.length != 2 || token[0] != 'bytes') {
-    return null;
-  }
-  return token[1].split(',')
-    .map(function(range) {
-      return range.split('-').map(function(value) {
-        if (value === '') {
-          return Infinity;
-        }
-        return Number(value);
-      });
-    })
-    .filter(function(range) {
-      return !isNaN(range[0]) && !isNaN(range[1]) && range[0] <= range[1];
-    });
-}
-
-function rangeContentGenerator(start, end, length) {
-  return util.format('bytes %d-%d/%s', start, end, length);
-}

--- a/index.js
+++ b/index.js
@@ -7,7 +7,9 @@ const fs            = require('fs');
 const isPreconditionFailure = require('./is-precondition-failure');
 const mime          = require('mime');
 const parseHttpDate = require('./parse-http-date');
-const parseRange    = require('range-parser');
+// TODO: I would much prefer to use the range-parser npm module but my PR is not getting any attention.
+// might be a dead project: https://github.com/jshttp/range-parser/pull/25
+const parseRange    = require('./range-parser');
 const pump          = require('pump');
 const rangeStream   = require('range-stream');
 const sbuff         = require('./buffer-stream'); 

--- a/index.js
+++ b/index.js
@@ -2,13 +2,15 @@
 
 const error         = require('./error');
 const etag          = require('etag');
-const fresh         = require('fresh');
+// TODO: I would much prefer to use the fresh npm module but my PR is not getting any attention.
+// seems to be a dead project.  https://github.com/jshttp/fresh/pull/34
+const fresh         = require('./fresh');
 const fs            = require('fs');
 const isPreconditionFailure = require('./is-precondition-failure');
 const mime          = require('mime');
 const parseHttpDate = require('./parse-http-date');
 // TODO: I would much prefer to use the range-parser npm module but my PR is not getting any attention.
-// might be a dead project: https://github.com/jshttp/range-parser/pull/25
+// seems to be a dead project.  https://github.com/jshttp/range-parser/pull/25
 const parseRange    = require('./range-parser');
 const pump          = require('pump');
 const rangeStream   = require('range-stream');

--- a/is-precondition-failure.js
+++ b/is-precondition-failure.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const parseHttpDate = require('./parse-http-date.js');
+
+
+module.exports = isPreconditionFailure;
+
+
+function isPreconditionFailure (ctx) {
+  const req = ctx.request;
+  const res = ctx.response;
+
+  // if-match
+  const match = req.get('if-match');
+  if (match) {
+    const etag = res.get('ETag');
+
+    return !etag || (match !== '*' && parseTokenList(match).every(function (match) {
+      return match !== etag && match !== 'W/' + etag && 'W/' + match !== etag;
+    }));
+  }
+
+  // if-unmodified-since
+  const unmodifiedSince = parseHttpDate(req.get('if-unmodified-since'));
+  if (!isNaN(unmodifiedSince)) {
+    const lastModified = parseHttpDate(res.get('Last-Modified'));
+    return isNaN(lastModified) || lastModified > unmodifiedSince;
+  }
+
+  return false;
+}
+
+
+/**
+ * Parse a HTTP token list.
+ *
+ * @param {string} str
+ * @private
+ */
+
+function parseTokenList (str) {
+  let end = 0;
+  const list = [ ];
+  let start = 0;
+
+  // gather tokens
+  for (let i = 0, len = str.length; i < len; i++) {
+    switch (str.charCodeAt(i)) {
+      case 0x20: /*   */
+        if (start === end)
+          start = end = i + 1;
+        break;
+
+      case 0x2c: /* , */
+        if (start !== end) {
+          list.push(str.substring(start, end));
+        }
+        start = end = i + 1;
+        break;
+
+      default:
+        end = i + 1;
+        break;
+    }
+  }
+
+  // final token
+  if (start !== end)
+    list.push(str.substring(start, end));
+
+  return list;
+}

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "fresh": "^0.5.2",
     "mime": "^2.0.0",
     "pump": "^3.0.0",
-    "range-parser": "github:mreinstein/range-parser",
     "range-stream": "^2.0.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   },
   "dependencies": {
     "etag": "^1.8.1",
-    "fresh": "^0.5.2",
     "mime": "^2.0.0",
     "pump": "^3.0.0",
     "range-stream": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -31,9 +31,14 @@
     "supertest": "^0.13.0"
   },
   "dependencies": {
-    "stream-slice": "^0.1.2"
+    "etag": "^1.8.1",
+    "fresh": "^0.5.2",
+    "mime": "^2.0.0",
+    "pump": "^3.0.0",
+    "range-parser": "github:mreinstein/range-parser",
+    "range-stream": "^2.0.0"
   },
-  "engines" : {
-    "node" : ">=7"
+  "engines": {
+    "node": ">=7"
   }
 }

--- a/parse-http-date.js
+++ b/parse-http-date.js
@@ -1,0 +1,17 @@
+'use strict';
+
+module.exports = parseHttpDate;
+
+
+/**
+ * Parse an HTTP Date into a number.
+ *
+ * @param {string} date
+ * @private
+ */
+
+function parseHttpDate (date) {
+  const timestamp = date && Date.parse(date);
+
+  return (typeof timestamp === 'number') ? timestamp : NaN;
+}

--- a/range-parser.js
+++ b/range-parser.js
@@ -1,0 +1,169 @@
+/*!
+ * range-parser
+ * Copyright(c) 2012-2014 TJ Holowaychuk
+ * Copyright(c) 2015-2016 Douglas Christopher Wilson
+ * MIT Licensed
+ */
+
+'use strict'
+
+/**
+ * Module exports.
+ * @public
+ */
+
+module.exports = rangeParser
+
+/**
+ * Parse "Range" header `str` relative to the given file `size`.
+ *
+ * @param {Number} size
+ * @param {String} str
+ * @param {Object} [options]
+ * @return {Array}
+ * @public
+ */
+
+function rangeParser (size, str, options) {
+  if (typeof str !== 'string') {
+    throw new TypeError('argument str must be a string')
+  }
+
+  var index = str.indexOf('=')
+
+  if (index === -1) {
+    return -2
+  }
+
+  // split the range string
+  var arr = str.slice(index + 1).split(',')
+  var ranges = []
+
+  // add ranges type
+  ranges.type = str.slice(0, index)
+
+  // parse all ranges
+  for (var i = 0; i < arr.length; i++) {
+    var range = arr[i].split('-')
+    var start = parseInt(range[0], 10)
+    var end = parseInt(range[1], 10)
+
+    // -nnn
+    if (isNaN(start)) {
+      if (range[0].length > 0) {
+        return -2
+      }
+
+      start = size - end
+      end = size - 1
+    // nnn-
+    } else if (isNaN(end)) {
+      if (range[1].length > 0) {
+        return -2
+      }
+      end = size - 1
+    }
+
+    // limit last-byte-pos to current length
+    if (end > size - 1) {
+      end = size - 1
+    }
+
+    // invalid or unsatisifiable
+    if (isNaN(start) || isNaN(end) || start > end || start < 0) {
+      continue
+    }
+
+    // add range
+    ranges.push({
+      start: start,
+      end: end
+    })
+  }
+
+  if (ranges.length < 1) {
+    // unsatisifiable
+    return -1
+  }
+
+  return options && options.combine
+    ? combineRanges(ranges)
+    : ranges
+}
+
+/**
+ * Combine overlapping & adjacent ranges.
+ * @private
+ */
+
+function combineRanges (ranges) {
+  var ordered = ranges.map(mapWithIndex).sort(sortByRangeStart)
+
+  for (var j = 0, i = 1; i < ordered.length; i++) {
+    var range = ordered[i]
+    var current = ordered[j]
+
+    if (range.start > current.end + 1) {
+      // next range
+      ordered[++j] = range
+    } else if (range.end > current.end) {
+      // extend range
+      current.end = range.end
+      current.index = Math.min(current.index, range.index)
+    }
+  }
+
+  // trim ordered array
+  ordered.length = j + 1
+
+  // generate combined range
+  var combined = ordered.sort(sortByRangeIndex).map(mapWithoutIndex)
+
+  // copy ranges type
+  combined.type = ranges.type
+
+  return combined
+}
+
+/**
+ * Map function to add index value to ranges.
+ * @private
+ */
+
+function mapWithIndex (range, index) {
+  return {
+    start: range.start,
+    end: range.end,
+    index: index
+  }
+}
+
+/**
+ * Map function to remove index value from ranges.
+ * @private
+ */
+
+function mapWithoutIndex (range) {
+  return {
+    start: range.start,
+    end: range.end
+  }
+}
+
+/**
+ * Sort function to sort ranges by index.
+ * @private
+ */
+
+function sortByRangeIndex (a, b) {
+  return a.index - b.index
+}
+
+/**
+ * Sort function to sort ranges by start position.
+ * @private
+ */
+
+function sortByRangeStart (a, b) {
+  return a.start - b.start
+}

--- a/test/simple.js
+++ b/test/simple.js
@@ -1,24 +1,37 @@
+'use strict';
 
-var fs = require('fs');
-var request = require('supertest');
-var should = require('should');
-var route = require('koa-route');
-var range = require('../');
-var Koa = require('koa');
-var app = new Koa();
+const etag     = require('etag');
+const fs       = require('fs');
+const request  = require('supertest');
+const should   = require('should');
+const route    = require('koa-route');
+const range    = require('../');
+const Koa      = require('koa');
+const Readable = require('stream').Readable;
 
-var rawbody = new Buffer(1024);
-var rawFileBuffer = fs.readFileSync('./README.md') + '';
+
+const app = new Koa();
+
+const rawbody = Buffer.alloc(1024);
+const rawFileBuffer = fs.readFileSync('./README.md') + '';
+
+const readmeStat = fs.statSync('./README.md');
+const readmeEtag = etag(readmeStat);
+const bufferEtag = etag(rawFileBuffer);
+const lastModifiedReadme = readmeStat.mtime.toUTCString()
 
 app.use(range);
 app.use(route.get('/', async function(ctx) {
   ctx.body = rawbody;
 }));
+app.use(route.put('/', async function(ctx) {
+  ctx.status = 200;
+}));
 app.use(route.post('/', async function(ctx) {
   ctx.status = 200;
 }));
 app.use(route.get('/json', async function(ctx) {
-  ctx.body = {foo:'bar'};
+  ctx.body = { foo:'bar' };
 }));
 app.use(route.get('/string', async function(ctx) {
   ctx.body = 'koa-range';
@@ -26,14 +39,20 @@ app.use(route.get('/string', async function(ctx) {
 app.use(route.get('/stream', async function(ctx) {
   ctx.body = fs.createReadStream('./README.md');
 }));
+
+app.use(route.get('/buffer', async function(ctx) {
+  ctx.body = Buffer.from(rawFileBuffer);
+}));
+
 app.use(route.get('/empty', async function(ctx) {
   ctx.body = undefined;
   ctx.status = 304;
 }));
 
-app.on('error', function(err) {
+app.on('error', function (err) {
   throw err;
 });
+
 
 describe('normal requests', function() {
 
@@ -45,10 +64,19 @@ describe('normal requests', function() {
     .end(done);
   });
 
-  it('should return 200 when method not GET', function(done) {
+  it('should ignore range headers when method not GET', function(done) {
     request(app.listen())
     .post('/')
     .set('range', 'bytes=0-300')
+    .expect('Accept-Ranges', 'bytes')
+    .expect(200)
+    .end(done);
+  });
+
+  it('should ignore range headers with PUT', function(done) {
+    request(app.listen())
+    .put('/')
+    .set('range', 'bytes=0-299')
     .expect('Accept-Ranges', 'bytes')
     .expect(200)
     .end(done);
@@ -66,15 +94,6 @@ describe('range requests', function() {
     .expect('Accept-Ranges', 'bytes')
     .expect('Content-Range', 'bytes 0-299/1024')
     .expect(206)
-    .end(done);
-  });
-
-  it('should return 400 with PUT', function(done) {
-    request(app.listen())
-    .put('/')
-    .set('range', 'bytes=0-299')
-    .expect('Accept-Ranges', 'bytes')
-    .expect(400)
     .end(done);
   });
 
@@ -116,6 +135,7 @@ describe('range requests', function() {
 
 });
 
+
 describe('range requests with stream', function() {
 
   it('should return 206 with partial content', function(done) {
@@ -124,6 +144,8 @@ describe('range requests with stream', function() {
     .set('range', 'bytes=0-99')
     .expect('Accept-Ranges', 'bytes')
     .expect('Content-Range', 'bytes 0-99/' + rawFileBuffer.length)
+    .expect('Last-Modified', lastModifiedReadme)
+    .expect('Etag', readmeEtag)
     .expect(206)
     .end(function(err, res) {
       should.not.exist(err);
@@ -146,6 +168,7 @@ describe('range requests with stream', function() {
   });
 
 });
+
 
 describe('range requests with json', function() {
 
@@ -180,6 +203,26 @@ describe('range requests with json', function() {
   });
 });
 
+
+describe('range requests with buffer', function() {
+  it('should return 206 with partial content', function(done) {
+    request(app.listen())
+    .get('/buffer')
+    .set('range', 'bytes=0-99')
+    .expect('Accept-Ranges', 'bytes')
+    .expect('Content-Range', 'bytes 0-99/' + rawFileBuffer.length)
+    .expect('Etag', bufferEtag)
+    .expect(206)
+    .end(function(err, res) {
+      should.not.exist(err);
+      should.not.exist(res.headers['last-modified']);
+      res.text.should.equal(rawFileBuffer.slice(0, 100));
+      done();
+    });
+  });
+});
+
+
 describe('range requests with string', function() {
 
   it('should return 206 with partial content', function(done) {
@@ -213,6 +256,7 @@ describe('range requests with string', function() {
   });
 });
 
+
 describe('range requests with empty body', function() {
   it('should return 304', function(done) {
     request(app.listen())
@@ -224,4 +268,89 @@ describe('range requests with empty body', function() {
       done();
     });
   });
+});
+
+
+describe('range requests with conditional GET', function() {
+
+  it('should return 412 with mismatching etag (precondition failure)', function(done) {
+    request(app.listen())
+    .get('/buffer')
+    .set('range', 'bytes=0-5')
+    .set('if-match', 'fake_etag_value_that_doesnt_match')
+    .expect('Accept-Ranges', 'bytes')
+    .expect(412)
+    .end(function(err, res) {
+      should.not.exist(err);
+      should.not.exist(res.headers['content-range']);
+      res.text.should.equal('');
+      done();
+    });
+  });
+
+  it('should return 206 with partial content', function(done) {
+    request(app.listen())
+    .get('/buffer')
+    .set('range', 'bytes=0-5')
+    .set('if-match', bufferEtag)
+    .expect('Accept-Ranges', 'bytes')
+    .expect('Content-Range', 'bytes 0-5/1904')
+    .expect('Content-Length', '6')
+    .expect(206)
+    .end(function(err, res) {
+      should.not.exist(err);
+      res.text.should.equal(rawFileBuffer.slice(0, 6));
+      //res.text.should.equal('koa-ra');
+      done();
+    });
+  });
+
+  it('should return 304 for cached content (if-none-match precondition)', function(done) {
+    request(app.listen())
+    .get('/stream')
+    .set('range', 'bytes=0-5')
+    .set('if-none-match', readmeEtag)
+    .expect('Accept-Ranges', 'bytes')
+    .expect(304)
+    .end(function(err, res) {
+      should.not.exist(err);
+      should.not.exist(res.headers['content-range']);
+      should.not.exist(res.headers['content-length']);
+      res.text.should.equal('');
+      done();
+    });
+  });
+
+  it('should return 304 for cached content (if-modified-since precondition)', function(done) {
+    request(app.listen())
+    .get('/stream')
+    .set('range', 'bytes=0-5')
+    .set('if-modified-since', new Date().toString())
+    .expect('Accept-Ranges', 'bytes')
+    .expect(304)
+    .end(function(err, res) {
+      should.not.exist(err);
+      should.not.exist(res.headers['content-range']);
+      should.not.exist(res.headers['content-length']);
+      res.text.should.equal('');
+      done();
+    });
+  });
+
+  it('should return 404 for not found resource', function(done) {
+    request(app.listen())
+    .get('/does_not_exist')
+    .set('range', 'bytes=0-5')
+    .set('if-modified-since', new Date().toString())
+    .expect('Accept-Ranges', 'bytes')
+    .expect(404)
+    .end(function(err, res) {
+      should.not.exist(err);
+      should.not.exist(res.headers['content-range']);
+      res.text.should.equal('Not Found');
+      res.headers['content-length'].should.equal('9');
+      done();
+    });
+  });
+
 });


### PR DESCRIPTION
changes:
* read through the range request (frc7232) and part of the conditional request (rfc7233) specs and updated the code to hopefully match them a bit more closely, espeically around etag/conditional GET/304 handling
* re-designed the architecture to create a stream regardless of source being a buffer, string, readable stream, or object
* updated the code to es6 since koa-range already relies on node >= 7
* expanded the unit tests

Note that there are a few problems:
* despite my best efforts I was unable to get "infinite" readable streams working properly (e.g., a radio station where the stream doesn't have a fixed content length. It was *sort* of working but there are some subtle details about stream handling in koa that elude me, so I dropped that feature.
* I'm currently using a module hosted on github  (`mreinstein/range-parser`) because I'm waiting on that upstream dependency to get merged. It's in a PR right now which I'm wating on  https://github.com/jshttp/range-parser/pull/25


It seems this project has been very dormant but if there's anyone around that ever worked on this thing and would like to provide feedback, I'd really appreciate any time you have. I spent the better part of the last week reading those 2 rfcs and trying a few proof of concepts so I'd love to not be working in a vacuum on this any longer. 😄 

@masx200 @yorkie @ZetaTwo @bortexz @haoxins  