### PR TITLE
Use HTTPS repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:yorkie/koa-range.git"
+    "url": "git+https://github.com/koajs/koa-range.git"
   },
   "keywords": [
     "range",

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
   "author": "Yorkie Neil <yorkiefixer@gmail.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/yorkie/koa-range/issues"
+    "url": "https://github.com/koajs/koa-range/issues"
   },
-  "homepage": "https://github.com/yorkie/koa-range",
+  "homepage": "https://github.com/koajs/koa-range",
   "devDependencies": {
     "istanbul": "^1.1.0-alpha.1",
     "koa": "^2.0.0",


### PR DESCRIPTION
## Summary

- replace the legacy SCP-style repository URL in `package.json`
- point package metadata at the current public GitHub repository over HTTPS

## Validation

- `node -e "const pkg=require('./package.json'); if(pkg.repository.url !== 'git+https://github.com/koajs/koa-range.git') throw new Error(pkg.repository.url)"`
- `node -e "JSON.parse(require('fs').readFileSync('package.json', 'utf8'))"`
- `git diff --check`
- `git ls-remote https://github.com/koajs/koa-range.git HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository URL configuration in package metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->